### PR TITLE
Fix: restrict Flask version to higher then v2.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-Flask
+Flask>=2.3.1
 werkzeug
 flask_dropzone
 click


### PR DESCRIPTION
Version v2.3.1 of flask fixes an exception thrown because of `Markup` import (as seen [here](https://flask.palletsprojects.com/en/2.3.x/changes/)) which affect mcritweb in its current state and causes mcritweb to crash on startup.

Also, it might be a good idea to pin all version of all dependencies to make a reliable state of the program without surprises