### PR TITLE
Add fallback to request context in `get_username`

### DIFF
--- a/mcritweb/views/api.py
+++ b/mcritweb/views/api.py
@@ -25,7 +25,7 @@ def handle_raw_response(response):
 @mcrit_server_required
 def api_router(api_path):
     api_path = api_path.rstrip("/")
-    username = get_username()
+    username = get_username(request)
     client = McritClient(mcrit_server=get_server_url(), apitoken=get_server_token(), username=username, raw_responses=True)
     print(f"api_router - {api_path} - {username}")
     if re.match("status", api_path):

--- a/mcritweb/views/utility.py
+++ b/mcritweb/views/utility.py
@@ -48,11 +48,12 @@ def get_session_user_id():
     except:
         return None
     
-def get_username():
-    username = "guest"
+def get_username(request=None):
     if g.user is not None:
-        username = g.user.username
-    return username
+        return g.user.username
+    elif request and "username" in request.headers:
+        return request.headers.get("username")
+    return "guest"
 
 
 def parse_band_range(request, from_form=False):


### PR DESCRIPTION
Right now, using the API passthrough in mcritweb from outside of the app context will result in the user being a guest, even if in the system they're of higher privilege. This PR will (try to) make it possible to fallback to user-specified username in headers.